### PR TITLE
Add prevent in source builds util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Project's root `CMakeLists.txt`.
 * `dependencies.cmake` and `dev-dependencies.cmake` scripts.
 * `CPM.cmake` script that downloads specified version of [CPM](https://github.com/cpm-cmake/CPM.cmake).
-* `dump()` and `dd()` utils functions, in `helpers.cmake`.
+* `dump()`, `dd()` and `fail_when_build_in_source()` utils functions, in `helpers.cmake`.
 * `semver_parse()`, `write_version_file` and `version_from_file()` utils, in `version.cmake`.
 * `git_find_version_tag()` util, in `git.cmake`.
 * `VERSION` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Project's root `CMakeLists.txt`.
 * `dependencies.cmake` and `dev-dependencies.cmake` scripts.
 * `CPM.cmake` script that downloads specified version of [CPM](https://github.com/cpm-cmake/CPM.cmake).
-* `dump()`, `dd()` and `fail_when_build_in_source()` utils functions, in `helpers.cmake`.
+* `dump()`, `dd()` and `fail_in_source_build()` utils functions, in `helpers.cmake`.
 * `semver_parse()`, `write_version_file` and `version_from_file()` utils, in `version.cmake`.
 * `git_find_version_tag()` util, in `git.cmake`.
 * `VERSION` file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ if(${hasModulePath} STREQUAL "-1")
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 endif()
 
-include("rsp/version")
+# Abort if building in-source
 include("rsp/helpers")
+fail_when_build_in_source()
 
 # Run only when this project is the root project
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -26,6 +27,7 @@ include("CPM")
 # -------------------------------------------------------------------------------------------------------------- #
 
 # Get project's version from file
+include("rsp/version")
 version_from_file(
     FILE "${CMAKE_CURRENT_SOURCE_DIR}/VERSION"
     OUTPUT version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # Abort if building in-source
 include("rsp/helpers")
-fail_when_build_in_source()
+fail_in_source_build()
 
 # Run only when this project is the root project
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/cmake/rsp/helpers.cmake
+++ b/cmake/rsp/helpers.cmake
@@ -14,7 +14,10 @@ if (NOT COMMAND "fail_in_source_build")
     # @throws
     #
     function(fail_in_source_build)
-        if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+        get_filename_component(sourceDir "${CMAKE_SOURCE_DIR}" REALPATH)
+        get_filename_component(binDir "${CMAKE_BINARY_DIR}" REALPATH)
+
+        if (${sourceDir} STREQUAL ${binDir})
             message(FATAL_ERROR "In-source builds are forbidden!")
         endif()
     endfunction()

--- a/cmake/rsp/helpers.cmake
+++ b/cmake/rsp/helpers.cmake
@@ -7,13 +7,13 @@ include_guard(GLOBAL)
 # Debug
 message(VERBOSE "rsp/helpers module included")
 
-if (NOT COMMAND "fail_when_build_in_source")
+if (NOT COMMAND "fail_in_source_build")
 
-    #! fail_when_build_in_source : Fails when building project in the source directory
+    #! fail_in_source_build : Fails when building project in the source directory
     #
     # @throws
     #
-    function(fail_when_build_in_source)
+    function(fail_in_source_build)
         if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
             message(FATAL_ERROR "In-source builds are forbidden!")
         endif()

--- a/cmake/rsp/helpers.cmake
+++ b/cmake/rsp/helpers.cmake
@@ -7,7 +7,21 @@ include_guard(GLOBAL)
 # Debug
 message(VERBOSE "rsp/helpers module included")
 
+if (NOT COMMAND "fail_when_build_in_source")
+
+    #! fail_when_build_in_source : Fails when building project in the source directory
+    #
+    # @throws
+    #
+    function(fail_when_build_in_source)
+        if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+            message(FATAL_ERROR "In-source builds are forbidden!")
+        endif()
+    endfunction()
+endif ()
+
 if (NOT COMMAND "dump")
+
     #! dump : Outputs given variables' name and value
     #
     # @param ... Variables to output
@@ -23,6 +37,7 @@ if (NOT COMMAND "dump")
 endif ()
 
 if (NOT COMMAND "dd")
+
     #! dump and die: Outputs given variables' name and value and stops build
     #
     # @param ... Variables to output


### PR DESCRIPTION
PR adds util that throws exception / fatal error, when building the project in the same directory as the source directory.
The project's `CmakeLists.txt` file now also invokes this function, as early as possible.

**Note**: _CMake might still create its `CMakeCache.txt` file in the root of the project, before the prevent function is triggered. Such a file SHOULD always be ignored by git._