### PR TITLE
Add build info

### DIFF
--- a/cmake/rsp/debug.cmake
+++ b/cmake/rsp/debug.cmake
@@ -7,6 +7,8 @@ include_guard(GLOBAL)
 # Debug
 message(VERBOSE "rsp/debug module included")
 
+include("rsp/output/utils")
+
 if (NOT COMMAND "dump")
 
     #! dump : Outputs given variables' name and value
@@ -36,5 +38,92 @@ if (NOT COMMAND "dd")
 
         # Output as fatal error to ensure that build stops.
         message(FATAL_ERROR "   ${CMAKE_CURRENT_FUNCTION}() called from ${CMAKE_CURRENT_LIST_FILE}")
+    endfunction()
+endif ()
+
+if(NOT COMMAND "build_info")
+
+    #! build_info : Output build information to stdout or stderr (Cmake's message type specific)
+    #
+    # @see https://cmake.org/cmake/help/latest/command/message.html
+    #
+    # @param [<mode>]                           Option - Cmake's message type. Defaults to NOTICE, when not specified.
+    # @param [OUTPUT <variable>]                Optional - If specified, message is assigned to output variable instead of
+    #                                           being printed to stdout or stderr.
+    #
+    # @return
+    #       [OUTPUT]                            The resulting output variable, if OUTPUT was specified.
+    #
+    function(build_info)
+        set(options "${RSP_CMAKE_MESSAGE_MODES}")
+        set(oneValueArgs OUTPUT)
+        set(multiValueArgs "")
+
+        cmake_parse_arguments(INPUT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        # Message mode
+        resolve_msg_mode("NOTICE")
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        set(info_list
+            # Build Type
+            # @see https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
+            "Type|${CMAKE_BUILD_TYPE}"
+
+            # Library Type (NOTE: LIB_TYPE is NOT a predefined cmake variable)
+            "Library Type|${LIB_TYPE}"
+
+            # Compiler flags
+            "Compiler flags|${CMAKE_CXX_COMPILE_FLAGS}"
+
+            # Compiler cxx debug flags
+            "Compiler cxx debug flags|${CMAKE_CXX_FLAGS_DEBUG}"
+
+            # Compiler cxx release flags
+            "Compiler cxx release flags|${CMAKE_CXX_FLAGS_RELEASE}"
+
+            # Compiler cxx min size flags
+            "Compiler cxx min size flags|${CMAKE_CXX_FLAGS_MINSIZEREL}"
+
+            # Compiler cxx flags
+            "Compiler cxx flags|${CMAKE_CXX_FLAGS}"
+        )
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        set(buffer "")
+
+        foreach (item IN LISTS info_list)
+            string(REPLACE "|" ";" parts "${item}")
+            list(GET parts 0 label)
+            list(GET parts 1 value)
+
+            list(APPEND buffer "${COLOR_MAGENTA}${label}:${RESTORE} ${value}")
+        endforeach ()
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        # Convert list to a string with newlines...
+        string(REPLACE ";" "\n" buffer "${buffer}")
+
+        # Attempt to keep the formatting - see details in rsp/output::output()
+        string(ASCII 13 CR)
+        set(formatted_output "${CR}${COLOR_BRIGHT_MAGENTA}build info:${RESTORE}\n${buffer}")
+        string(REPLACE "\n" "\n " formatted_output "${formatted_output}")
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        # Assign to output variable, if requested and stop any further processing.
+        if (DEFINED INPUT_OUTPUT)
+            set("${INPUT_OUTPUT}" "${formatted_output}")
+            return(PROPAGATE "${INPUT_OUTPUT}")
+        endif ()
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        message(${msg_mode} "${formatted_output}")
     endfunction()
 endif ()

--- a/docs/+current/modules/debug/build_info.md
+++ b/docs/+current/modules/debug/build_info.md
@@ -1,0 +1,36 @@
+---
+title: Build Info
+description: Using git_find_version_tag
+keywords: debug, debugging, build info, cmake
+author: RSP Systems A/S
+---
+
+# Build Info
+
+The `build_info()` function dumps build information about the current build.
+It accepts the following parameter:
+
+* < mode >: (_option_), _cmake [message mode](https://cmake.org/cmake/help/latest/command/message.html#general-messages), e.g. `WARNING`, `NOTICE`, `STATUS`, ...etc._
+  _Defaults to `NOTICE` is mode is not specified._
+* `OUTPUT`: (_optional_), _output variable. If specified, message is assigned to variable, instead of being printed to `stdout` or `stderr`._
+
+## Example
+
+```cmake
+set(LIB_TYPE "SHARED")
+
+build_info()
+```
+
+Outputs a message similar to this (_not all properties are shown in example_):
+
+```txt
+build info:
+ Type: Debug
+ Library Type: SHARED
+ Compiler flags: ...
+ Compiler cxx debug flags: ... 
+ Compiler cxx release flags: ...
+ Compiler cxx min size flags: ...
+ Compiler cxx flags: ...
+```

--- a/tests/unit/debug/build_info_test.cmake
+++ b/tests/unit/debug/build_info_test.cmake
@@ -1,0 +1,32 @@
+include("rsp/testing")
+include("rsp/debug")
+
+define_test_case(
+        "Build Info Test"
+        LABELS "debug;build_info"
+)
+
+# -------------------------------------------------------------------------------------------------------------- #
+# Actual Tests
+# -------------------------------------------------------------------------------------------------------------- #
+
+define_test("can output build info" "outputs_build_info")
+function(outputs_build_info)
+
+    # Set a few of the build info variables
+    set(CMAKE_BUILD_TYPE "Debug")
+    set(LIB_TYPE "STATIC")
+
+    # ---------------------------------------------------------------------- #
+
+    build_info(OUTPUT result)
+
+    # Debug
+    # message("${result}")
+
+    # ---------------------------------------------------------------------- #
+
+    # Ensure that a few of the properties are in the output
+    assert_string_contains("${result}" "Type: ${CMAKE_BUILD_TYPE}" MESSAGE "Incorrect build info output (build type)")
+    assert_string_contains("${result}" "Library Type: ${LIB_TYPE}" MESSAGE "Incorrect build info output (library type)")
+endfunction()


### PR DESCRIPTION
PR adds `build_info()`, a function that dumps information about the current build.

## Details

See the docs and test for examples.
