### PR TITLE
Redesign safeguard properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Project's root `CMakeLists.txt`.
 * `dependencies.cmake` and `dev-dependencies.cmake` scripts.
 * `CPM.cmake` script that downloads specified version of [CPM](https://github.com/cpm-cmake/CPM.cmake).
-* `fail_in_source_build()`, `extract_value()`, `requires_arguments()` and `safeguard_properties()` utils functions, in `helpers.cmake`.
+* `fail_in_source_build()`, `extract_value()`, `requires_arguments()` and `safeguard_properties()` utils, in `helpers.cmake`.
 * `dump()`, `dd()` and `var_dump()` in `debug.cmake`.
 * ANSI utils, in `output.cmake`
 * `semver_parse()`, `write_version_file` and `version_from_file()` utils, in `version.cmake`.

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -4,7 +4,7 @@
 
 include_guard()
 
-function(install_dependencies)
+macro(install_dependencies)
     message(STATUS "Installing Dependencies for ${PROJECT_NAME}")
 
     # Avoid building tests for dependencies...
@@ -12,6 +12,5 @@ function(install_dependencies)
 
     # Add dependencies here...
     message(STATUS "    N/A")
-
-endfunction()
-safeguard_properties(CALLBACK "install_dependencies" PROPERTIES BUILD_TESTING)
+endmacro()
+safeguard_properties("install_dependencies" "BUILD_TESTING")

--- a/dev-dependencies.cmake
+++ b/dev-dependencies.cmake
@@ -7,7 +7,7 @@ include_guard()
 # Include regular dependencies
 include("dependencies.cmake")
 
-function(install_dev_dependencies)
+macro(install_dev_dependencies)
     message(STATUS "Installing Development Dependencies for ${PROJECT_NAME}")
 
     # Avoid building tests for dependencies...
@@ -15,6 +15,5 @@ function(install_dev_dependencies)
 
     # Add dev-dependencies here...
     message(STATUS "    N/A")
-
-endfunction()
-safeguard_properties(CALLBACK "install_dev_dependencies" PROPERTIES BUILD_TESTING)
+endmacro()
+safeguard_properties("install_dev_dependencies" "BUILD_TESTING")

--- a/tests/unit/helpers/safeguard_properties_test.cmake
+++ b/tests/unit/helpers/safeguard_properties_test.cmake
@@ -1,5 +1,6 @@
 include("rsp/testing")
 include("rsp/helpers")
+include("rsp/debug")
 
 define_test_case(
     "Safeguard Properties Test"
@@ -13,18 +14,14 @@ function(can_safeguard_properties)
     set(c "ccc")
 
     function(risky_callback)
+        message(VERBOSE "risky callback invoked (function)")
+
         set(a "1" PARENT_SCOPE)
         set(b "2" PARENT_SCOPE)
         set(c "3" PARENT_SCOPE)
     endfunction()
 
-    safeguard_properties(
-        CALLBACK "risky_callback"
-        PROPERTIES
-            a
-            b
-            c
-    )
+    safeguard_properties("risky_callback" "a;b;c")
 
     # Debug
     #risky_callback()
@@ -32,4 +29,29 @@ function(can_safeguard_properties)
     assert_string_equals("aaa" ${a} MESSAGE "Property a was modified")
     assert_string_equals("bbb" ${b} MESSAGE "Property b was modified")
     assert_string_equals("ccc" ${c} MESSAGE "Property c was modified")
+endfunction()
+
+define_test("unguarded properties can be changed" "unguarded_properties_can_be_changed")
+function(unguarded_properties_can_be_changed)
+    set(a "aaa")
+    set(b "bbb")
+    set(c "ccc")
+
+    macro(risky_callback)
+        message(NOTICE "risky callback invoked (macro)")
+
+        set(a "1")
+        set(b "2")
+        set(c "3")
+    endmacro()
+
+    # Note: "c" is NOT safeguarded here
+    safeguard_properties("risky_callback" "a;b")
+
+    # Debug
+    #risky_callback()
+
+    assert_string_equals("aaa" ${a} MESSAGE "Property a was modified")
+    assert_string_equals("bbb" ${b} MESSAGE "Property b was modified")
+    assert_string_equals("3" ${c} MESSAGE "Property c SHOULD had been modified")
 endfunction()


### PR DESCRIPTION
After the issues that have been identified concerning the propagation of `CMAKE_MODULE_PATH` (in #15), I realized that our `safeguard_properties()` utility function and its applied use for safeguarding the `BUILD_TESTING` option, was no longer a viable solution. 

This PR redesigns `safeguard_properties()` to be a macro, instead of a function. Doing so ensures that whatever callback we execute can modify any property, such as the `CMAKE_MODULE_PATH`, without being encapsulated within a function's variable scope. Now, any 3rd party dependency that we define should not be affected, as is the case when using CPM.

## References

* #15
