### PR TITLE
Fix cmake module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `CMAKE_MODULE_PATH` changes are not propagated to the top-most project, when "CMake Scripts" is included by other project as a nested dependency. 
 * Release (_version_) links in `CHANGELOG.md`.
 
 ## [v0.1.0] - 2025-02-13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ option(RSP_ENABLE_ANSI "Enable ANSI output" false)
 list(FIND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" has_cmake_scripts_module_path)
 if(has_cmake_scripts_module_path EQUAL -1)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" CACHE STRING " RSP CMake Scripts CMAKE_MODULE_PATH" FORCE)
+
+    message(WARNING "Caching CMAKE_MODULE_PATH. Please rebuild your project, if a failure occur.")
 endif()
 
 # Abort if building in-source


### PR DESCRIPTION
PR caches the `CMAKE_MODULE_PATH` changes, such that a top-most project will be able to include util modules defined by this project, even when "CMake Scripts" is a deep nested dependency.
