### PR TITLE
Add var_dump_all()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `var_dump_all()` macro in `debug.cmake`.
+
 ### Changed
 
 * Reformatted release (_version_) headings in `CHANGELOG.md`. 

--- a/cmake/rsp/debug.cmake
+++ b/cmake/rsp/debug.cmake
@@ -204,6 +204,24 @@ if (NOT COMMAND "var_dump")
     endfunction()
 endif ()
 
+if (NOT COMMAND "var_dump_all")
+
+    #! var_dump_all : Outputs human-readable information about CMake's current defined variables
+    #
+    # @see https://cmake.org/cmake/help/latest/prop_dir/VARIABLES.html#variables
+    #
+    macro(var_dump_all)
+        # Get the global VARIABLES
+        # @see https://cmake.org/cmake/help/latest/prop_dir/VARIABLES.html#variables
+        get_cmake_property(_global_vars VARIABLES)
+        list (SORT _global_vars)
+
+        foreach (_var "${_global_vars}")
+            var_dump(PROPERTIES ${_var})
+        endforeach()
+    endmacro()
+endif ()
+
 if(NOT COMMAND "build_info")
 
     #! build_info : Output build information to stdout or stderr (Cmake's message type specific)

--- a/docs/+current/modules/debug/dump.md
+++ b/docs/+current/modules/debug/dump.md
@@ -197,3 +197,33 @@ Outputs:
 ```txt
 my_list = (string 15) "foo;bar;42;true"
 ```
+
+## `var_dump_all()`
+
+**Available Since: `v0.2.0`**
+
+Outputs human-readable information about CMake's current defined variables.
+
+_See Cmake's [`VARIABLES`](https://cmake.org/cmake/help/latest/prop_dir/VARIABLES.html) for additional information._
+
+```cmake
+var_dump_all()
+```
+
+Outputs:
+
+```txt
+ALERT_LEVEL = (command, cached) ALERT_LEVEL()
+BUILD_TESTING = (string 0) ""
+CMAKE_AUTOGEN_ORIGIN_DEPENDS = (string 2) "ON"
+CMAKE_AUTOMOC_COMPILER_PREDEFINES = (string 2) "ON"
+CMAKE_AUTOMOC_MACRO_NAMES = (list 4) [ 
+   0: (string 8) "Q_OBJECT"
+   1: (string 8) "Q_GADGET"
+   2: (string 11) "Q_NAMESPACE"
+   3: (string 18) "Q_NAMESPACE_EXPORT"
+]
+CMAKE_AUTOMOC_PATH_PREFIX = (string 3) "OFF"
+
+... remaining not shown
+```


### PR DESCRIPTION
PS adds `var_dump_all()` util. It outputs all current variables in CMake.

## References

* https://cmake.org/cmake/help/latest/prop_dir/VARIABLES.html
