### PR TITLE
Add gcc_version()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `var_dump_all()` macro in `debug.cmake`.
+* `gcc_version()` function in `compilers/gcc.cmake`.
 
 ### Changed
 

--- a/cmake/rsp/compilers/gcc.cmake
+++ b/cmake/rsp/compilers/gcc.cmake
@@ -192,3 +192,44 @@ if (NOT DEFINED RSP_GCC_STRICT_COMPILE_OPTIONS)
         #-dD
     )
 endif ()
+
+if (NOT COMMAND "gcc_version")
+
+    #! gcc_version : Returns the GCC tool version
+    #
+    # @param OUTPUT <variable>            The variable to assign result to.
+    #
+    # @return
+    #       [OUTPUT]                      GCC version.
+    #
+    function(gcc_version)
+        set(options "")
+        set(oneValueArgs OUTPUT)
+        set(multiValueArgs "")
+
+        cmake_parse_arguments(INPUT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+        requires_arguments("OUTPUT" INPUT)
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        find_program(GCC_TOOL NAMES g++-latest g++-HEAD g++-14 g++-13 g++-12 g++-11)
+
+        execute_process(
+            COMMAND ${GCC_TOOL} --version
+            OUTPUT_VARIABLE GCC_TOOL_VERSION
+            ERROR_VARIABLE GCC_TOOL_VERSION
+        )
+
+        string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" GCC_TOOL_VERSION "${GCC_TOOL_VERSION}")
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        # Set the resulting version
+        set("${INPUT_OUTPUT}" "${GCC_TOOL_VERSION}")
+
+        return(
+            PROPAGATE
+            "${INPUT_OUTPUT}"
+        )
+    endfunction()
+endif ()

--- a/docs/+current/modules/compiler/gcc.md
+++ b/docs/+current/modules/compiler/gcc.md
@@ -37,3 +37,17 @@ set(my_compile_options "${RSP_GCC_STRICT_COMPILE_OPTIONS}")
 # Modify your preset...
 list(REMOVE_ITEM my_compile_options "-Wswitch-default")
 ```
+
+## `gcc_version()`
+
+**Available Since: `v0.2.0`**
+
+Obtains the installed GCC version. The function accepts the following parameters:
+
+* `OUTPUT`: _Output variable to assign the result to._
+
+```cmake
+gcc_version(OUTPUT version)
+
+message("GCC: ${version}") # 14.2.0
+```

--- a/tests/unit/compilerse/gcc_version_test.cmake
+++ b/tests/unit/compilerse/gcc_version_test.cmake
@@ -1,0 +1,19 @@
+include("rsp/testing")
+include("rsp/compilers/gcc")
+
+define_test_case(
+    "GCC Version Test"
+    LABELS "gcc;version;compilers"
+)
+
+# -------------------------------------------------------------------------------------------------------------- #
+# Actual tests
+# -------------------------------------------------------------------------------------------------------------- #
+
+define_test("can obtain GCC version" "can_obtain_gcc_version")
+function(can_obtain_gcc_version)
+
+    gcc_version(OUTPUT version)
+
+    assert_string_not_empty("${version}" MESSAGE "GCC version not obtained")
+endfunction()


### PR DESCRIPTION
PR adds a new `gcc_version()` util function. It assigns the obtained GCC version to an `OUTPUT` parameter.
