### PR TITLE
Add gcc info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+* `gcc_info()` function in `compilers/gcc.cmake`.
+
+### Changed
+
+* `gcc_version()` now uses `gcc_info()` to obtain GCC version.
+
+### Fixed
+
+* Internal property bleeds into global scope, when calling `gcc_version()`, due auto caching by `find_program()`. 
+
 ## [v0.2.0] - 2025-03-18
 
 ### Added

--- a/cmake/rsp/compilers/gcc.cmake
+++ b/cmake/rsp/compilers/gcc.cmake
@@ -193,6 +193,50 @@ if (NOT DEFINED RSP_GCC_STRICT_COMPILE_OPTIONS)
     )
 endif ()
 
+if (NOT COMMAND "gcc_info")
+
+    #! gcc_version : Assigns path to the available / installed GCC and its version
+    #
+    # @param OUTPUT <variable>            The variable to assign result to.
+    #
+    # @return
+    #       [OUTPUT]                      Path to GCC.
+    #       [OUTPUT]_VERSION              GCC version.
+    #
+    function(gcc_info)
+        set(options "")
+        set(oneValueArgs OUTPUT)
+        set(multiValueArgs "")
+
+        cmake_parse_arguments(INPUT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+        requires_arguments("OUTPUT" INPUT)
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        find_program(GCC_TOOL NAMES g++-latest g++-HEAD g++-14 g++-13 g++-12 g++-11 NO_CACHE)
+
+        execute_process(
+                COMMAND ${GCC_TOOL} --version
+                OUTPUT_VARIABLE GCC_TOOL_VERSION
+                ERROR_VARIABLE GCC_TOOL_VERSION
+        )
+
+        string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" GCC_TOOL_VERSION "${GCC_TOOL_VERSION}")
+
+        # ---------------------------------------------------------------------------------------------- #
+
+        # Set the resulting path and version
+        set("${INPUT_OUTPUT}" "${GCC_TOOL}")
+        set("${INPUT_OUTPUT}_VERSION" "${GCC_TOOL_VERSION}")
+
+        return(
+            PROPAGATE
+            "${INPUT_OUTPUT}"
+            "${INPUT_OUTPUT}_VERSION"
+        )
+    endfunction()
+endif ()
+
 if (NOT COMMAND "gcc_version")
 
     #! gcc_version : Returns the GCC tool version
@@ -212,20 +256,12 @@ if (NOT COMMAND "gcc_version")
 
         # ---------------------------------------------------------------------------------------------- #
 
-        find_program(GCC_TOOL NAMES g++-latest g++-HEAD g++-14 g++-13 g++-12 g++-11 NO_CACHE)
-
-        execute_process(
-            COMMAND ${GCC_TOOL} --version
-            OUTPUT_VARIABLE GCC_TOOL_VERSION
-            ERROR_VARIABLE GCC_TOOL_VERSION
-        )
-
-        string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" GCC_TOOL_VERSION "${GCC_TOOL_VERSION}")
+        gcc_info(OUTPUT result)
 
         # ---------------------------------------------------------------------------------------------- #
 
         # Set the resulting version
-        set("${INPUT_OUTPUT}" "${GCC_TOOL_VERSION}")
+        set("${INPUT_OUTPUT}" "${result_VERSION}")
 
         return(
             PROPAGATE

--- a/cmake/rsp/compilers/gcc.cmake
+++ b/cmake/rsp/compilers/gcc.cmake
@@ -212,7 +212,7 @@ if (NOT COMMAND "gcc_version")
 
         # ---------------------------------------------------------------------------------------------- #
 
-        find_program(GCC_TOOL NAMES g++-latest g++-HEAD g++-14 g++-13 g++-12 g++-11)
+        find_program(GCC_TOOL NAMES g++-latest g++-HEAD g++-14 g++-13 g++-12 g++-11 NO_CACHE)
 
         execute_process(
             COMMAND ${GCC_TOOL} --version

--- a/docs/+current/modules/compiler/gcc.md
+++ b/docs/+current/modules/compiler/gcc.md
@@ -38,6 +38,28 @@ set(my_compile_options "${RSP_GCC_STRICT_COMPILE_OPTIONS}")
 list(REMOVE_ITEM my_compile_options "-Wswitch-default")
 ```
 
+## `gcc_info()`
+
+**Available Since: `v0.3.0`**
+
+Obtains the path and version of the installed GCC version. The function accepts the following parameters:
+
+* `OUTPUT`: _Output variable to assign the result to._
+
+**Output**
+
+* `[OUTPUT]`: _Path to installed GCC tool._
+* `[OUTPUT]_VERSION`: _GCC version._
+
+**Example**
+
+```cmake
+gcc_info(OUTPUT gcc)
+
+message("GCC (path): ${gcc}") # /usr/bin/g++-14
+message("GCC (version): ${gcc_VERSION}") # 14.2.0
+```
+
 ## `gcc_version()`
 
 **Available Since: `v0.2.0`**

--- a/tests/unit/compilerse/gcc_info_test.cmake
+++ b/tests/unit/compilerse/gcc_info_test.cmake
@@ -1,0 +1,23 @@
+include("rsp/testing")
+include("rsp/compilers/gcc")
+include("rsp/debug")
+
+define_test_case(
+    "GCC Info Test"
+    LABELS "gcc;version;compilers"
+)
+
+# -------------------------------------------------------------------------------------------------------------- #
+# Actual tests
+# -------------------------------------------------------------------------------------------------------------- #
+
+define_test("can obtain GCC path and version" "can_obtain_gcc_info")
+function(can_obtain_gcc_info)
+
+    gcc_info(OUTPUT result)
+
+    assert_string_not_empty("${result}" MESSAGE "GCC path not obtained")
+
+    assert_defined("result_VERSION" MESSAGE "GCC Version not defined")
+    assert_string_not_empty("${result_VERSION}" MESSAGE "GCC path not obtained")
+endfunction()


### PR DESCRIPTION
PR adds a new `gcc_info()` util function that is able to obtain the path to GCC and the version. In addition, it also fixes the issue that an internal "GCC_TOOL" property was bleeding into CMake's global scope, due to auto-caching of variable by Cmake's [`find_program`](https://cmake.org/cmake/help/latest/command/find_program.html#find-program).